### PR TITLE
change the warning log if both of the webhookURL and API token are provided

### DIFF
--- a/main.go
+++ b/main.go
@@ -150,7 +150,7 @@ func validate(conf *Config) error {
 	}
 
 	if conf.APIToken != "" && conf.WebhookURL != "" {
-		log.Warnf("Both API Token and WebhookURL is provided. Using the API Token")
+		log.Warnf("Both API Token and WebhookURL are provided. Using the API Token")
 		conf.WebhookURL = ""
 
 	}

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func postMessage(conf Config, msg Message) error {
 
 func validate(conf *Config) error {
 	if conf.APIToken == "" && conf.WebhookURL == "" {
-		return fmt.Errorf("Both API Token and WebhookURL is empty. You need to provide one of them. If you want to use incoming webhooks provide the webhook url. If you want to use a bot to send a message provide the bot API token")
+		return fmt.Errorf("Both API Token and WebhookURL are empty. You need to provide one of them. If you want to use incoming webhooks provide the webhook url. If you want to use a bot to send a message provide the bot API token")
 	}
 
 	if conf.APIToken != "" && conf.WebhookURL != "" {

--- a/main.go
+++ b/main.go
@@ -124,7 +124,6 @@ func postMessage(conf Config, msg Message) error {
 	client := &http.Client{}
 
 	resp, err := client.Do(req)
-
 	if err != nil {
 		return fmt.Errorf("failed to send the request: %s", err)
 	}
@@ -145,13 +144,15 @@ func postMessage(conf Config, msg Message) error {
 	return nil
 }
 
-func validate(conf Config) error {
+func validate(conf *Config) error {
 	if conf.APIToken == "" && conf.WebhookURL == "" {
 		return fmt.Errorf("Both API Token and WebhookURL is empty. You need to provide one of them. If you want to use incoming webhooks provide the webhook url. I you want to use a bot to send a message provide the bot API token")
 	}
 
 	if conf.APIToken != "" && conf.WebhookURL != "" {
-		log.Warnf("Both API Token and WebhookURL is provided. Using the webhook url")
+		log.Warnf("Both API Token and WebhookURL is provided. Using the API Token")
+		conf.WebhookURL = ""
+
 	}
 	return nil
 }
@@ -165,7 +166,7 @@ func main() {
 	stepconf.Print(conf)
 	log.SetEnableDebugLog(conf.Debug)
 
-	if err := validate(conf); err != nil {
+	if err := validate(&conf); err != nil {
 		log.Errorf("Error: %s\n", err)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -146,7 +146,7 @@ func postMessage(conf Config, msg Message) error {
 
 func validate(conf *Config) error {
 	if conf.APIToken == "" && conf.WebhookURL == "" {
-		return fmt.Errorf("Both API Token and WebhookURL is empty. You need to provide one of them. If you want to use incoming webhooks provide the webhook url. I you want to use a bot to send a message provide the bot API token")
+		return fmt.Errorf("Both API Token and WebhookURL is empty. You need to provide one of them. If you want to use incoming webhooks provide the webhook url. If you want to use a bot to send a message provide the bot API token")
 	}
 
 	if conf.APIToken != "" && conf.WebhookURL != "" {


### PR DESCRIPTION
if both of them are provided then use the API token and remove the webhookURL