### PR TITLE
Trim whitespace from ends of webhook URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -109,7 +109,7 @@ func postMessage(conf Config, msg Message) error {
 	}
 	log.Debugf("Request to Slack: %s\n", b)
 
-	url := string(conf.WebhookURL)
+	url := strings.TrimSpace(string(conf.WebhookURL))
 	if string(conf.APIToken) != "" {
 		url = "https://slack.com/api/chat.postMessage"
 	}


### PR DESCRIPTION
Was getting a terrible error when trying to use this slack notification plugin. looked like below:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x38 pc=0x1271158]
goroutine 1 [running]:
main.postMessage(0x1, 0xc0000260cc, 0x50, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, 0x0, ...)
	/var/folders/6q/wgy6jtp12w5gzgm9lzcglpqw0000gn/T/bitrise-go-toolkit174703979/src/github.com/bitrise-io/steps-slack-message/main.go:118 +0x288
main.main()
	/var/folders/6q/wgy6jtp12w5gzgm9lzcglpqw0000gn/T/bitrise-go-toolkit174703979/src/github.com/bitrise-io/steps-slack-message/main.go:175 +0x348
WARN[22:28:05] Step (slack@3) failed, but was marked as skippable 
|                                                                              |
+---+---------------------------------------------------------------+----------+
| ! | slack@3 (exit code: 2)                                        | 11.00 sec|
+---+---------------------------------------------------------------+----------+
| Issue tracker: https://github.com/bitrise-io/steps-slack-message/issues      |
| Source: https://github.com/bitrise-io/steps-slack-message                    |
+---+---------------------------------------------------------------+----------+
```


Turns out, I accidentally added a newline when adding the SLACK_WEBHOOK_URL secret to my config. Took me quite a while to track down what was causing this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bitrise-steplib/steps-slack-message/66)
<!-- Reviewable:end -->
