### PR TITLE
Update main.go to work around issue with default URL

### DIFF
--- a/main.go
+++ b/main.go
@@ -110,7 +110,7 @@ func postMessage(conf Config, msg Message) error {
 	log.Debugf("Request to Slack: %s\n", b)
 
 	url := strings.TrimSpace(string(conf.WebhookURL))
-	if string(conf.APIToken) != "" {
+	if string(conf.APIToken) == "" {
 		url = "https://slack.com/api/chat.postMessage"
 	}
 


### PR DESCRIPTION
the code is saying, that if provided string is not null - i.e., provided by the user, override it with the default URL, which is wrong, I believe.