### PR TITLE
allow a different webhook to be used to send messages on build failures

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,19 +19,20 @@ type Config struct {
 	Debug bool `env:"is_debug_mode,opt[yes,no]"`
 
 	// Message
-	WebhookURL       stepconf.Secret `env:"webhook_url"`
-	APIToken         stepconf.Secret `env:"api_token"`
-	Channel          string          `env:"channel"`
-	ChannelOnError   string          `env:"channel_on_error"`
-	Text             string          `env:"text"`
-	TextOnError      string          `env:"text_on_error"`
-	IconEmoji        string          `env:"emoji"`
-	IconEmojiOnError string          `env:"emoji_on_error"`
-	IconURL          string          `env:"icon_url"`
-	IconURLOnError   string          `env:"icon_url_on_error"`
-	LinkNames        bool            `env:"link_names,opt[yes,no]"`
-	Username         string          `env:"from_username"`
-	UsernameOnError  string          `env:"from_username_on_error"`
+	WebhookURL        stepconf.Secret `env:"webhook_url"`
+	WebhookURLOnError stepconf.Secret `env:"webhook_url_on_error"`
+	APIToken          stepconf.Secret `env:"api_token"`
+	Channel           string          `env:"channel"`
+	ChannelOnError    string          `env:"channel_on_error"`
+	Text              string          `env:"text"`
+	TextOnError       string          `env:"text_on_error"`
+	IconEmoji         string          `env:"emoji"`
+	IconEmojiOnError  string          `env:"emoji_on_error"`
+	IconURL           string          `env:"icon_url"`
+	IconURLOnError    string          `env:"icon_url_on_error"`
+	LinkNames         bool            `env:"link_names,opt[yes,no]"`
+	Username          string          `env:"from_username"`
+	UsernameOnError   string          `env:"from_username_on_error"`
 
 	// Attachment
 	Color           string `env:"color,required"`
@@ -109,7 +110,7 @@ func postMessage(conf Config, msg Message) error {
 	}
 	log.Debugf("Request to Slack: %s\n", b)
 
-	url := strings.TrimSpace(string(conf.WebhookURL))
+	url := strings.TrimSpace(selectValue(string(conf.WebhookURL), string(conf.WebhookURLOnError)))
 	if url == "" {
 		url = "https://slack.com/api/chat.postMessage"
 	}

--- a/step.yml
+++ b/step.yml
@@ -72,6 +72,15 @@ inputs:
          To register an **Incoming WebHook integration** visit: https://api.slack.com/incoming-webhooks
       is_required: false
       is_sensitive: true
+  - webhook_url_on_error:
+    opts:
+      title: "Slack Webhook URL (Webhook or API token is required) if the build failed"
+      description: |
+         **Either webhook\_url or api\_token input is required.**
+         To register an **Incoming WebHook integration** visit: https://api.slack.com/incoming-webhooks
+      is_required: false
+      is_sensitive: true
+      category: If Build Failed
   - api_token: 
     opts:
       title: "Slack API token (Webhook or API token is required)"


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context
When using a webhook to send slack messages, the channel in which the message is posted relies on the webhook's linked channel. This change allows a different channel to used to send messages to in the case of a failure, when webhooks are used and not an api token.

<!-- Please link the issue that the PR fixes.
There is no issue associated w/this
-->

### Changes

- add a new optional field in the yml for adding a webhook to use when the build fails.
- add a new property in the `Config` struct: `WebhookURLOnError`
- use the `WebhookURLOnError` when there is an error and it is populated

### Investigation details

- this was the only solution I could think of to allow a different slack channel to be used when the build fails

### Decisions

- tried to follow what already existed
