### PR TITLE
Trim whitespace in channel names

### DIFF
--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func ensureNewlines(s string) string {
 
 func newMessage(c Config) Message {
 	msg := Message{
-		Channel: selectValue(c.Channel, c.ChannelOnError),
+		Channel: selectValue(strings.TrimSpace(c.Channel), c.ChannelOnError),
 		Text:    selectValue(c.Text, c.TextOnError),
 		Attachments: []Attachment{{
 			Fallback:   ensureNewlines(selectValue(c.Message, c.MessageOnError)),

--- a/main.go
+++ b/main.go
@@ -74,7 +74,7 @@ func ensureNewlines(s string) string {
 
 func newMessage(c Config) Message {
 	msg := Message{
-		Channel: selectValue(strings.TrimSpace(c.Channel), c.ChannelOnError),
+		Channel: strings.TrimSpace(selectValue(c.Channel, c.ChannelOnError)),
 		Text:    selectValue(c.Text, c.TextOnError),
 		Attachments: []Attachment{{
 			Fallback:   ensureNewlines(selectValue(c.Message, c.MessageOnError)),


### PR DESCRIPTION
…reated

<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR/MINOR/PATCH* [version update](https://semver.org/)

### Context

The channel name would contain whitespaces when space is added in the input field which was then used in creating new messages


Resolves: #75 


### Changes

While creating the new message the white spaces in the channel if any are removed by using the strings package trimspaces method

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
