### PR TITLE
Support sending messages into thread

### DIFF
--- a/main.go
+++ b/main.go
@@ -19,20 +19,24 @@ type Config struct {
 	Debug bool `env:"is_debug_mode,opt[yes,no]"`
 
 	// Message
-	WebhookURL        stepconf.Secret `env:"webhook_url"`
-	WebhookURLOnError stepconf.Secret `env:"webhook_url_on_error"`
-	APIToken          stepconf.Secret `env:"api_token"`
-	Channel           string          `env:"channel"`
-	ChannelOnError    string          `env:"channel_on_error"`
-	Text              string          `env:"text"`
-	TextOnError       string          `env:"text_on_error"`
-	IconEmoji         string          `env:"emoji"`
-	IconEmojiOnError  string          `env:"emoji_on_error"`
-	IconURL           string          `env:"icon_url"`
-	IconURLOnError    string          `env:"icon_url_on_error"`
-	LinkNames         bool            `env:"link_names,opt[yes,no]"`
-	Username          string          `env:"from_username"`
-	UsernameOnError   string          `env:"from_username_on_error"`
+	WebhookURL            stepconf.Secret `env:"webhook_url"`
+	WebhookURLOnError     stepconf.Secret `env:"webhook_url_on_error"`
+	APIToken              stepconf.Secret `env:"api_token"`
+	Channel               string          `env:"channel"`
+	ChannelOnError        string          `env:"channel_on_error"`
+	Text                  string          `env:"text"`
+	TextOnError           string          `env:"text_on_error"`
+	IconEmoji             string          `env:"emoji"`
+	IconEmojiOnError      string          `env:"emoji_on_error"`
+	IconURL               string          `env:"icon_url"`
+	IconURLOnError        string          `env:"icon_url_on_error"`
+	LinkNames             bool            `env:"link_names,opt[yes,no]"`
+	Username              string          `env:"from_username"`
+	UsernameOnError       string          `env:"from_username_on_error"`
+	ThreadTs              string          `env:"thread_ts"`
+	ThreadTsOnError       string          `env:"thread_ts_on_error"`
+	ReplyBroadcast        bool            `env:"reply_broadcast,opt[yes,no]"`
+	ReplyBroadcastOnError bool            `env:"reply_broadcast_on_error,opt[yes,no]"`
 
 	// Attachment
 	Color           string `env:"color,required"`
@@ -67,6 +71,14 @@ func selectValue(ifSuccess, ifFailed string) string {
 	return ifFailed
 }
 
+// selectBool chooses the right boolean value based on the result of the build.
+func selectBool(ifSuccess, ifFailed bool) bool {
+	if success {
+		return ifSuccess
+	}
+	return ifFailed
+}
+
 // ensureNewlines replaces all \n substrings with newline characters.
 func ensureNewlines(s string) string {
 	return strings.Replace(s, "\\n", "\n", -1)
@@ -91,10 +103,12 @@ func newMessage(c Config) Message {
 			FooterIcon: c.FooterIcon,
 			Buttons:    parseButtons(c.Buttons),
 		}},
-		IconEmoji: selectValue(c.IconEmoji, c.IconEmojiOnError),
-		IconURL:   selectValue(c.IconURL, c.IconURLOnError),
-		LinkNames: c.LinkNames,
-		Username:  selectValue(c.Username, c.UsernameOnError),
+		IconEmoji:       selectValue(c.IconEmoji, c.IconEmojiOnError),
+		IconURL:         selectValue(c.IconURL, c.IconURLOnError),
+		LinkNames:       c.LinkNames,
+		Username:        selectValue(c.Username, c.UsernameOnError),
+		ThreadTs:        selectValue(c.ThreadTs, c.ThreadTsOnError),
+		ReplyBroadcast:  selectBool(c.ReplyBroadcast, c.ReplyBroadcastOnError),
 	}
 	if c.TimeStamp {
 		msg.Attachments[0].TimeStamp = int(time.Now().Unix())

--- a/message.go
+++ b/message.go
@@ -30,6 +30,12 @@ type Message struct {
 
 	// Username specifies the bot's username for the message.
 	Username string `json:"username,omitempty"`
+
+	// Provide another message's ts value to make this message a reply.
+	ThreadTs string `json:"thread_ts,omitempty"`
+
+	// Used in conjunction with thread_ts and indicates whether reply should be made visible to everyone in the channel or conversation.
+	ReplyBroadcast bool `json:"reply_broadcast,omitempty"`
 }
 
 // Attachment adds more context to a slack chat message.

--- a/step.yml
+++ b/step.yml
@@ -177,6 +177,31 @@ inputs:
         leave this option empty then the default one will be used.
       category: If Build Failed
 
+  - thread_ts:
+    opts:
+      title: Thread Timestamp
+      description: Sends the message as a reply to the message with the given ts if set (in a thread).
+  - thread_ts_on_error:
+    opts:
+      title: Thread Timestamp if the build failed
+      description: Sends the message as a reply to the message with the given ts if set (in a thread) if the build failed.
+      category: If Build Failed
+  - reply_broadcast: "no"
+    opts:
+      title: Reply Broadcast
+      description: Used in conjunction with thread_ts and indicates whether reply should be made visible to everyone in the channel or conversation
+      value_options:
+      - "yes"
+      - "no"
+  - reply_broadcast_on_error: "no"
+    opts:
+      title: Reply Broadcast if the build failed
+      description: Used in conjunction with thread_ts and indicates whether reply should be made visible to everyone in the channel or conversation
+      category: If Build Failed
+      value_options:
+      - "yes"
+      - "no"
+
 # Attachment inputs
         
   - color: "#3bc3a3"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

Hey, I did read the contributing guide and saw that you aren't accepting community enhancements, but I had already made the changes to test the feasibility and decided to submit the PR anyway. Please feel free to close if it's an issue but hopefully it's a simple one!

Resolves: https://discuss.bitrise.io/t/send-slack-messages-into-threaded-replies/19940

The [Slack API](https://api.slack.com/methods/chat.postMessage) accepts a `thread_ts` and `reply_broadcast` parameter that allow us to send messages as a threaded reply (and optionally broadcast that reply back to the main channel) and I would love for the Bitrise Slack step to be able to support this. 

### Changes

- Added `thread_ts`, `thread_ts_on_error`, `reply_broadcast` and `reply_broadcast_on_error` to the step.yml configuration with documentation.
- Updated the `Message` struct to define `ThreadTs` (string) and `ReplyBroadcast` (bool) properties.
- Updated `Config` to read `ThreadTs`, `ThreadTsOnError`, `ReplyBroadcast` and `ReplyBroadcastOnError` from the env 
- Updated `newMessage` to pass appropriate values through from `Config` into `Message`
  - Defined an additional `selectBool` function similar to `selectValue` that chooses the appropriate value for Messages `ReplyBroadcast` property

The changes are 100% backwards compatible, and while I don't think there are unit tests for this step, I have tested my fork in a workflow to confirm that it works as I am expecting. 