### PR TITLE
Export thread timestamp

### DIFF
--- a/main.go
+++ b/main.go
@@ -210,6 +210,7 @@ func main() {
 func export_outputs(conf *Config, resp *http.Response) error {
 
 	if !is_requesting_output(conf) {
+		log.Debugf("Not requesting any outputs")
 		return nil
 	}
 
@@ -227,11 +228,14 @@ func export_outputs(conf *Config, resp *http.Response) error {
 	}
 
 	if string(conf.ThreadTsOutputVariableName) != "" {
+		log.Debugf("Exporting output: %s=%s\n", string(conf.ThreadTsOutputVariableName), response.Timestamp)
 		err := export(string(conf.ThreadTsOutputVariableName), response.Timestamp)
 		if err != nil {
 			return err
 		}
 	}
+
+	return nil
 
 }
 

--- a/outputs.go
+++ b/outputs.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os/exec"
+	"strings"
+
+	"github.com/bitrise-io/go-utils/log"
+)
+
+/// The response from Slack POST
+type SendMessageResponse struct {
+	/// The Thread Timestamp
+	Timestamp string `json:"ts"`
+}
+
+/// Export the output variables after a successful response
+func exportOutputs(conf *Config, resp *http.Response) error {
+
+	if !isRequestingOutput(conf) {
+		log.Debugf("Not requesting any outputs")
+		return nil
+	}
+
+	is_webhook := strings.TrimSpace(selectValue(string(conf.WebhookURL), string(conf.WebhookURLOnError))) != ""
+
+	// Slack webhooks do not return any useful response information
+	if is_webhook {
+		return fmt.Errorf("For output support, do not submit a WebHook URL")
+	}
+
+	var response SendMessageResponse
+	parseError := json.NewDecoder(resp.Body).Decode(&response)
+	if parseError != nil {
+		return fmt.Errorf("failed to send the request: %s", parseError)
+	}
+
+	if string(conf.ThreadTsOutputVariableName) != "" {
+		log.Debugf("Exporting output: %s=%s\n", string(conf.ThreadTsOutputVariableName), response.Timestamp)
+		err := exportEnvVariable(string(conf.ThreadTsOutputVariableName), response.Timestamp)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+
+}
+
+/// Checks if we are requesting an output of anything
+func isRequestingOutput(conf *Config) bool {
+	return string(conf.ThreadTsOutputVariableName) != ""
+}
+
+/// Exports env using envman
+func exportEnvVariable(variable string, value string) error {
+	c := exec.Command("envman", "add", "--key", variable, "--value", value)
+	err := c.Run()
+	if err != nil {
+		return fmt.Errorf("Failed to run envman %s", err)
+	}
+	return nil
+}

--- a/outputs.go
+++ b/outputs.go
@@ -34,7 +34,8 @@ func exportOutputs(conf *Config, resp *http.Response) error {
 	var response SendMessageResponse
 	parseError := json.NewDecoder(resp.Body).Decode(&response)
 	if parseError != nil {
-		return fmt.Errorf("failed to send the request: %s", parseError)
+		// here we want to fail, because the user is expecting an output
+		return fmt.Errorf("Failed to parse response: %s", parseError)
 	}
 
 	if string(conf.ThreadTsOutputVariableName) != "" {

--- a/step.yml
+++ b/step.yml
@@ -353,7 +353,7 @@ inputs:
 
 # Step Outputs
 
-  - created_thread_ts_env_name:
+  - output_thread_ts:
     opts:
       title: The newly created thread timestamp environment variable name
       description: Will export the created thread's timestamp to the environment with the supplied name (if not already in thread)

--- a/step.yml
+++ b/step.yml
@@ -350,3 +350,12 @@ inputs:
         The *text* is the label for the button.
         The *url* is the fully qualified http or https url to deliver users to.
         An attachment may contain 1 to 5 buttons.
+
+# Step Outputs
+
+  - created_thread_ts_env_name:
+    opts:
+      title: The newly created thread timestamp environment variable name
+      description: Will export the created thread's timestamp to the environment with the supplied name (if not already in thread)
+      is_required: false
+      is_sensitive: false


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *PATCH* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->
Ability to export outputs from the step such as `thread_ts`

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->
#60 

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->
Added an extra function that is run to export any requested output environment variable.
These have not been added as global step output for 2 reasons:
1- To maintain legacy functionality
2- To prevent unnecessary response parsing 
3- Prevent environment variable clash in case this step if available multiple times in a workflow

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
1- added a new file called output.go
1- add extra input in step.yml: that would be the env variable name to export the thread_ts as
2- add some code to make it happen 
