### PR TITLE
[SWAT-595] Add support for multiline Field values

### DIFF
--- a/bitrise.yml
+++ b/bitrise.yml
@@ -75,7 +75,7 @@ workflows:
             multi_line_msg="Multi\nline\n\ntext"
             envman add --key SLACK_MESSAGE_FROM_SCRIPT --value "$multi_line_msg"
     - path::./:
-        title: Should escape backslash+n as newline char
+        title: Should escape backslash+n as newline char + custom multiline release notes field
         is_skippable: false
         inputs:
         - webhook_url: $SLACK_WEBHOOK_URL
@@ -83,6 +83,11 @@ workflows:
         - channel: $SLACK_CHANNEL
         - from_username: step-dev-test
         - message: $SLACK_MESSAGE_FROM_SCRIPT
+        - fields: |
+            Release notes|${multi_line_msg}
+            App|${BITRISE_APP_TITLE}
+            Branch|${BITRISE_GIT_BRANCH}
+            Workflow|${BITRISE_TRIGGERED_WORKFLOW_ID}
   fail-message-test:
     steps:
     - script:

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -72,7 +72,7 @@ workflows:
             #!/bin/bash
             set -ex
 
-            multi_line_msg="Multi\nline\n\ntext"
+            multi_line_msg="Multiline, with a link: https://www.bitrise.io, \n _some_ *highlight*, \n and linkify @slackbot #random"
             envman add --key SLACK_MESSAGE_FROM_SCRIPT --value "$multi_line_msg"
     - path::./:
         title: Should escape backslash+n as newline char + custom multiline release notes field

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -84,7 +84,7 @@ workflows:
         - from_username: step-dev-test
         - message: $SLACK_MESSAGE_FROM_SCRIPT
         - fields: |
-            Release notes|${multi_line_msg}
+            Release notes|${SLACK_MESSAGE_FROM_SCRIPT}
             App|${BITRISE_APP_TITLE}
             Branch|${BITRISE_GIT_BRANCH}
             Workflow|${BITRISE_TRIGGERED_WORKFLOW_ID}

--- a/message.go
+++ b/message.go
@@ -130,7 +130,7 @@ func (f Field) MarshalJSON() ([]byte, error) {
 
 func parseFields(s string) (fs []Field) {
 	for _, p := range pairs(s) {
-		fs = append(fs, Field{Title: p[0], Value: strings.Replace(p[1], "\\n", "\n", -1)})
+		fs = append(fs, Field{Title: p[0], Value: ensureNewlines(p[1])})
 	}
 	return
 }

--- a/message.go
+++ b/message.go
@@ -130,7 +130,7 @@ func (f Field) MarshalJSON() ([]byte, error) {
 
 func parseFields(s string) (fs []Field) {
 	for _, p := range pairs(s) {
-		fs = append(fs, Field{Title: p[0], Value: p[1]})
+		fs = append(fs, Field{Title: p[0], Value: strings.Replace(p[1], "\\n", "\n", -1)})
 	}
 	return
 }

--- a/message_test.go
+++ b/message_test.go
@@ -1,0 +1,27 @@
+package main
+
+import (
+	"reflect"
+	"testing"
+)
+
+func Test_parseFields(t *testing.T) {
+	tests := []struct {
+		name   string
+		s      string
+		wantFs []Field
+	}{
+		{
+			name:   "Newline in release notes",
+			s:      "Release notes|line1\\nline2",
+			wantFs: []Field{{Title: "Release notes", Value: "line1\nline2"}},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if gotFs := parseFields(tt.s); !reflect.DeepEqual(gotFs, tt.wantFs) {
+				t.Errorf("parseFields() = %v, want %v", gotFs, tt.wantFs)
+			}
+		})
+	}
+}

--- a/step.yml
+++ b/step.yml
@@ -332,10 +332,13 @@ inputs:
       description: |
         Fields separated by newlines and each field contains a `title` and a `value`.
         The `title` and the `value` fields are separated by a pipe `|` character.
-        Empty lines and lines without a separator are omitted.
         
         The *title* shown as a bold heading above the `value` text.
         The *value* is the text value of the field.
+        
+        Supports multiline text with escaped newlines. Example: `Release notes| - Line1 \n -Line2`.
+
+        Empty lines and lines without a separator are omitted.
   - buttons: |
       View App|${BITRISE_APP_URL}
       View Build|${BITRISE_BUILD_URL}


### PR DESCRIPTION
### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [X] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *MINOR* [version update](https://semver.org/)

### Context

Multi-line strings for fields are not supported. Adds support for newlines in a limited way as they have to be escaped.
Example:
```
- fields: |
    Release notes|- Line1 \n -Line2
    App|${BITRISE_APP_TITLE}
    Branch|${BITRISE_GIT_BRANCH}
    Workflow|${BITRISE_TRIGGERED_WORKFLOW_ID}
```

Resolves: https://discuss.bitrise.io/t/multiline-field-in-slack-message/21038/6

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

