### PR TITLE
Fail on errors returned from the Slack API when using API Token

### DIFF
--- a/main.go
+++ b/main.go
@@ -176,6 +176,11 @@ func validate(conf *Config) error {
 		conf.WebhookURL = ""
 
 	}
+
+	if conf.APIToken == "" && isRequestingOutput(conf) {
+		return fmt.Errorf("Outputs can only be set when using the API Token.")
+	}
+
 	return nil
 }
 

--- a/main.go
+++ b/main.go
@@ -159,8 +159,8 @@ func postMessage(conf Config, msg Message) error {
 		return fmt.Errorf("server error: %s, response: %s", resp.Status, body)
 	}
 
-	if err := exportOutputs(&conf, resp); err != nil {
-		return fmt.Errorf("failed to export outputs: %s", err)
+	if err := processResponse(&conf, resp); err != nil {
+		return err
 	}
 
 	return nil

--- a/outputs.go
+++ b/outputs.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"os/exec"
-	"strings"
 
 	"github.com/bitrise-io/go-utils/log"
 )
@@ -18,18 +17,6 @@ type SendMessageResponse struct {
 
 /// Export the output variables after a successful response
 func exportOutputs(conf *Config, resp *http.Response) error {
-
-	if !isRequestingOutput(conf) {
-		log.Debugf("Not requesting any outputs")
-		return nil
-	}
-
-	isWebhook := strings.TrimSpace(selectValue(string(conf.WebhookURL), string(conf.WebhookURLOnError))) != ""
-
-	// Slack webhooks do not return any useful response information
-	if isWebhook {
-		return fmt.Errorf("For output support, do not submit a WebHook URL")
-	}
 
 	var response SendMessageResponse
 	parseError := json.NewDecoder(resp.Body).Decode(&response)

--- a/outputs.go
+++ b/outputs.go
@@ -10,19 +10,36 @@ import (
 )
 
 // SendMessageResponse is the response from Slack POST
+// https://api.slack.com/methods/chat.postMessage#examples
 type SendMessageResponse struct {
+	/// The status of the request. When `false`, check the Error for a reason
+	Ok bool `json:"ok"`
+
+	/// Describes an error that prevented the message from being sent
+	Error string `json:"error"`
+
 	/// The Thread Timestamp
 	Timestamp string `json:"ts"`
 }
 
-/// Export the output variables after a successful response
-func exportOutputs(conf *Config, resp *http.Response) error {
+// Check the response status and set any output variables if required
+func processResponse(conf *Config, resp *http.Response) error {
+	// if the request was made using a legacy webhook url, skip processing as there is no response.
+	if conf.APIToken == "" {
+		log.Debugf("Skipping response processing because legacy webhook urls do not return any content")
+		return nil
+	}
 
 	var response SendMessageResponse
 	parseError := json.NewDecoder(resp.Body).Decode(&response)
 	if parseError != nil {
 		// here we want to fail, because the user is expecting an output
 		return fmt.Errorf("Failed to parse response: %s", parseError)
+	}
+
+	// if slack didn't return 'ok', fail with the error code
+	if !response.Ok {
+		return fmt.Errorf("Slack responded with error: %s", response.Error)
 	}
 
 	if string(conf.ThreadTsOutputVariableName) != "" {
@@ -37,12 +54,12 @@ func exportOutputs(conf *Config, resp *http.Response) error {
 
 }
 
-/// Checks if we are requesting an output of anything
+// Checks if we are requesting an output of anything
 func isRequestingOutput(conf *Config) bool {
 	return string(conf.ThreadTsOutputVariableName) != ""
 }
 
-/// Exports env using envman
+// Exports env using envman
 func exportEnvVariable(variable string, value string) error {
 	c := exec.Command("envman", "add", "--key", variable, "--value", value)
 	err := c.Run()


### PR DESCRIPTION
### Checklist

- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version

Requires a *PATCH* [version update](https://semver.org/)

### Context

In #44 the Step was updated to support both legacy (fire and forget) webhooks as well as the `chat.postMessage` API method that is part of the Slack API (via the API Token). With this, there is a bit of a change of how errors are reported. 

The legacy webhook would just fail if it wasn't valid and generally a HTTP 200 response indicated that it sent the message, which lines up with the logic that currently exists:

https://github.com/bitrise-steplib/steps-slack-message/blob/b38da2389d7fc5a09cf9b6f34db710f0c8a8ca29/main.go#L154-L160

However the Slack API does not work in the same way. Failures to send messages still result in a HTTP 200 response and instead the status is described as part JSON response. For example, if we make a request with an invalid token:

```
$ curl -X POST \ 
  -i \
  -H 'Authorization: Bearer BAD_AUTH' \
  -H 'Content-type: application/json; charset=utf-8' \
  --data '{"channel":"foo","text": "bar"}' \
  https://slack.com/api/chat.postMessage

HTTP/2 200 
date: Wed, 22 Feb 2023 21:17:57 GMT
server: Apache
x-powered-by: HHVM/4.153.1
access-control-allow-origin: *
referrer-policy: no-referrer
x-slack-backend: r
x-slack-unique-id: Y_aGhYqByRwZTLeYlWkr_QAAAB0
strict-transport-security: max-age=31536000; includeSubDomains; preload
access-control-allow-headers: slack-route, x-slack-version-ts, x-b3-traceid, x-b3-spanid, x-b3-parentspanid, x-b3-sampled, x-b3-flags
access-control-expose-headers: x-slack-req-id, retry-after
expires: Mon, 26 Jul 1997 05:00:00 GMT
cache-control: private, no-cache, no-store, must-revalidate
pragma: no-cache
x-robots-tag: noindex,nofollow
x-xss-protection: 0
x-content-type-options: nosniff
x-slack-req-id: c0625637e45fd91493a372dd0035be76
vary: Accept-Encoding
content-type: application/json; charset=utf-8
x-envoy-upstream-service-time: 101
x-backend: main_normal main_canary_with_overflow main_control_with_overflow
x-server: slack-www-hhvm-main-iad-czbn
x-slack-shared-secret-outcome: no-match
via: envoy-www-iad-cakx, envoy-edge-fra-jcnw
x-edge-backend: envoy-www
x-slack-edge-shared-secret-outcome: no-match

{"ok":false,"error":"invalid_auth"}%    
```

With the current implementation this means that Bitrise will continue as if the Slack message had sent successfully even if it didn't. This coupled with Slack apps being easy to misconfigure means that we can often end up spending a lot of extra time trying to work out what went wrong when it would be really helpful to have that error printed to us.

Some other use cases that I ran into during my time configuring things:

1. My `api_token` was invalid (`invalid_auth`)
2. Bot wasn't invited to the channel (`channel_not_found`)
3. Bot didn't have the right permission to send a message (`invalid_scopes`)

### Changes

To improve this, my aim is to always attempt to parse the JSON response when using `api_token`. If `ok` is `false`, we fail and include the `error` in the message.

While #82 updated the step to start parsing the response, it would only do it conditionally if the `output_thread_ts` was set so I have also made additional changes to account for this. 

As part of this change, instead of erroring if you incorrectly use `output_thread_ts` and `webhook_url` *after** the request is sent, I moved the check into the existing `validate` method that runs after loading the `Config`.

<img width="1011" alt="Screenshot 2023-02-22 at 22 29 59" src="https://user-images.githubusercontent.com/482871/220763481-ae58bc89-607f-49eb-bf5e-1b97e308d6a5.png">

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
