### PR TITLE
feat: add state inputs and pipeline support

### DIFF
--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 	"github.com/bitrise-tools/go-steputils/stepconf"
 )
 
-type InputConfig struct {
+type inputConfig struct {
 	Debug bool `env:"is_debug_mode,opt[yes,no]"`
 
 	// Message
@@ -36,7 +36,7 @@ type InputConfig struct {
 
 // Input ...
 type Input struct {
-	InputConfig
+	inputConfig
 
 	// Message
 	WebhookURL            stepconf.Secret `env:"webhook_url"`
@@ -79,8 +79,8 @@ type Input struct {
 	ThreadTsOutputVariableName string `env:"output_thread_ts"`
 }
 
-type Config struct {
-	InputConfig
+type config struct {
+	inputConfig
 
 	// Message
 	WebhookURL     string
@@ -106,7 +106,7 @@ func ensureNewlines(s string) string {
 	return strings.Replace(s, "\\n", "\n", -1)
 }
 
-func newMessage(c Config) Message {
+func newMessage(c config) Message {
 	msg := Message{
 		Channel: strings.TrimSpace(c.Channel),
 		Text:    c.Text,
@@ -139,7 +139,7 @@ func newMessage(c Config) Message {
 }
 
 // postMessage sends a message to a channel.
-func postMessage(conf Config, msg Message) error {
+func postMessage(conf config, msg Message) error {
 	b, err := json.Marshal(msg)
 	if err != nil {
 		return err
@@ -198,7 +198,7 @@ func validate(inp *Input) error {
 	return nil
 }
 
-func parseInputIntoConfig(inp *Input) Config {
+func parseInputIntoConfig(inp *Input) config {
 	pipelineSuccess := inp.PipelineBuildStatus == "" ||
 		inp.PipelineBuildStatus == "succeeded" ||
 		inp.PipelineBuildStatus == "succeeded_with_abort"
@@ -212,8 +212,8 @@ func parseInputIntoConfig(inp *Input) Config {
 		return ifFailed
 	}
 
-	var config = Config{
-		InputConfig:    inp.InputConfig,
+	var config = config{
+		inputConfig:    inp.inputConfig,
 		WebhookURL:     selectValue(string(inp.WebhookURL), string(inp.WebhookURLOnError)),
 		Channel:        selectValue(inp.Channel, inp.ChannelOnError),
 		Text:           selectValue(inp.Text, inp.TextOnError),

--- a/main.go
+++ b/main.go
@@ -184,24 +184,12 @@ func validate(conf *Config) error {
 	return nil
 }
 
-func getState(cfg *Config) string {
-	if cfg.State != "auto" {
-		return cfg.State
-	}
-
+func setSuccess(cfg *Config) {
 	pipelineSuccess := cfg.PipelineBuildStatus == "" ||
 		cfg.PipelineBuildStatus == "succeeded" ||
 		cfg.PipelineBuildStatus == "succeeded_with_abort"
 
-	if pipelineSuccess && cfg.BuildStatus == "0" {
-		return "success"
-	}
-	return "failure"
-}
-
-func setSuccess(conf *Config) {
-	var state = getState(conf)
-	success = state == "success"
+	success = pipelineSuccess && cfg.BuildStatus == "0"
 }
 
 func main() {

--- a/main.go
+++ b/main.go
@@ -14,7 +14,8 @@ import (
 	"github.com/bitrise-tools/go-steputils/stepconf"
 )
 
-type inputConfig struct {
+// InputConfig ...
+type InputConfig struct {
 	Debug bool `env:"is_debug_mode,opt[yes,no]"`
 
 	// Message
@@ -36,7 +37,7 @@ type inputConfig struct {
 
 // Input ...
 type Input struct {
-	inputConfig
+	InputConfig
 
 	// Message
 	WebhookURL            stepconf.Secret `env:"webhook_url"`
@@ -80,7 +81,7 @@ type Input struct {
 }
 
 type config struct {
-	inputConfig
+	InputConfig
 
 	// Message
 	WebhookURL     string
@@ -213,7 +214,7 @@ func parseInputIntoConfig(inp *Input) config {
 	}
 
 	var config = config{
-		inputConfig:    inp.inputConfig,
+		InputConfig:    inp.InputConfig,
 		WebhookURL:     selectValue(string(inp.WebhookURL), string(inp.WebhookURLOnError)),
 		Channel:        selectValue(inp.Channel, inp.ChannelOnError),
 		Text:           selectValue(inp.Text, inp.TextOnError),

--- a/main.go
+++ b/main.go
@@ -14,30 +14,9 @@ import (
 	"github.com/bitrise-tools/go-steputils/stepconf"
 )
 
-// InputConfig ...
-type InputConfig struct {
-	Debug bool `env:"is_debug_mode,opt[yes,no]"`
-
-	// Message
-	APIToken  stepconf.Secret `env:"api_token"`
-	LinkNames bool            `env:"link_names,opt[yes,no]"`
-
-	// Attachment
-	AuthorName string `env:"author_name"`
-	TitleLink  string `env:"title_link"`
-	Footer     string `env:"footer"`
-	FooterIcon string `env:"footer_icon"`
-	TimeStamp  bool   `env:"timestamp,opt[yes,no]"`
-	Fields     string `env:"fields"`
-	Buttons    string `env:"buttons"`
-
-	// Step Outputs
-	ThreadTsOutputVariableName string `env:"output_thread_ts"`
-}
-
 // Input ...
 type Input struct {
-	InputConfig
+	Debug bool `env:"is_debug_mode,opt[yes,no]"`
 
 	// Message
 	WebhookURL            stepconf.Secret `env:"webhook_url"`
@@ -57,6 +36,7 @@ type Input struct {
 	ThreadTsOnError       string          `env:"thread_ts_on_error"`
 	ReplyBroadcast        bool            `env:"reply_broadcast,opt[yes,no]"`
 	ReplyBroadcastOnError bool            `env:"reply_broadcast_on_error,opt[yes,no]"`
+	LinkNames             bool            `env:"link_names,opt[yes,no]"`
 
 	// Attachment
 	Color           string `env:"color,required"`
@@ -71,6 +51,13 @@ type Input struct {
 	ImageURLOnError string `env:"image_url_on_error"`
 	ThumbURL        string `env:"thumb_url"`
 	ThumbURLOnError string `env:"thumb_url_on_error"`
+	AuthorName      string `env:"author_name"`
+	TitleLink       string `env:"title_link"`
+	Footer          string `env:"footer"`
+	FooterIcon      string `env:"footer_icon"`
+	TimeStamp       bool   `env:"timestamp,opt[yes,no]"`
+	Fields          string `env:"fields"`
+	Buttons         string `env:"buttons"`
 
 	// Status
 	BuildStatus         string `env:"build_status"`
@@ -81,9 +68,10 @@ type Input struct {
 }
 
 type config struct {
-	InputConfig
+	Debug bool `env:"is_debug_mode,opt[yes,no]"`
 
 	// Message
+	APIToken       stepconf.Secret `env:"api_token"`
 	WebhookURL     string
 	Channel        string
 	Text           string
@@ -92,14 +80,25 @@ type config struct {
 	Username       string
 	ThreadTs       string
 	ReplyBroadcast bool
+	LinkNames      bool `env:"link_names,opt[yes,no]"`
 
 	// Attachment
-	Color    string
-	PreText  string
-	Title    string
-	Message  string
-	ImageURL string
-	ThumbURL string
+	Color      string
+	PreText    string
+	Title      string
+	Message    string
+	ImageURL   string
+	ThumbURL   string
+	AuthorName string `env:"author_name"`
+	TitleLink  string `env:"title_link"`
+	Footer     string `env:"footer"`
+	FooterIcon string `env:"footer_icon"`
+	TimeStamp  bool   `env:"timestamp,opt[yes,no]"`
+	Fields     string `env:"fields"`
+	Buttons    string `env:"buttons"`
+
+	// Step Outputs
+	ThreadTsOutputVariableName string `env:"output_thread_ts"`
 }
 
 // ensureNewlines replaces all \n substrings with newline characters.
@@ -214,21 +213,31 @@ func parseInputIntoConfig(inp *Input) config {
 	}
 
 	var config = config{
-		InputConfig:    inp.InputConfig,
-		WebhookURL:     selectValue(string(inp.WebhookURL), string(inp.WebhookURLOnError)),
-		Channel:        selectValue(inp.Channel, inp.ChannelOnError),
-		Text:           selectValue(inp.Text, inp.TextOnError),
-		IconEmoji:      selectValue(inp.IconEmoji, inp.IconEmojiOnError),
-		IconURL:        selectValue(inp.IconURL, inp.IconURLOnError),
-		Username:       selectValue(inp.Username, inp.UsernameOnError),
-		ThreadTs:       selectValue(inp.ThreadTs, inp.ThreadTsOnError),
-		ReplyBroadcast: (success && inp.ReplyBroadcast) || (!success && inp.ReplyBroadcastOnError),
-		Color:          selectValue(inp.Color, inp.ColorOnError),
-		PreText:        selectValue(inp.PreText, inp.PreTextOnError),
-		Title:          selectValue(inp.Title, inp.TitleOnError),
-		Message:        selectValue(inp.Message, inp.MessageOnError),
-		ImageURL:       selectValue(inp.ImageURL, inp.ImageURLOnError),
-		ThumbURL:       selectValue(inp.ThumbURL, inp.ThumbURLOnError),
+		Debug:                      inp.Debug,
+		APIToken:                   inp.APIToken,
+		WebhookURL:                 selectValue(string(inp.WebhookURL), string(inp.WebhookURLOnError)),
+		Channel:                    selectValue(inp.Channel, inp.ChannelOnError),
+		Text:                       selectValue(inp.Text, inp.TextOnError),
+		IconEmoji:                  selectValue(inp.IconEmoji, inp.IconEmojiOnError),
+		IconURL:                    selectValue(inp.IconURL, inp.IconURLOnError),
+		Username:                   selectValue(inp.Username, inp.UsernameOnError),
+		ThreadTs:                   selectValue(inp.ThreadTs, inp.ThreadTsOnError),
+		ReplyBroadcast:             (success && inp.ReplyBroadcast) || (!success && inp.ReplyBroadcastOnError),
+		LinkNames:                  inp.LinkNames,
+		Color:                      selectValue(inp.Color, inp.ColorOnError),
+		PreText:                    selectValue(inp.PreText, inp.PreTextOnError),
+		Title:                      selectValue(inp.Title, inp.TitleOnError),
+		Message:                    selectValue(inp.Message, inp.MessageOnError),
+		ImageURL:                   selectValue(inp.ImageURL, inp.ImageURLOnError),
+		ThumbURL:                   selectValue(inp.ThumbURL, inp.ThumbURLOnError),
+		AuthorName:                 inp.AuthorName,
+		TitleLink:                  inp.TitleLink,
+		Footer:                     inp.Footer,
+		FooterIcon:                 inp.FooterIcon,
+		TimeStamp:                  inp.TimeStamp,
+		Fields:                     inp.Fields,
+		Buttons:                    inp.Buttons,
+		ThreadTsOutputVariableName: inp.ThreadTsOutputVariableName,
 	}
 	return config
 

--- a/main.go
+++ b/main.go
@@ -93,12 +93,12 @@ type Config struct {
 	ReplyBroadcast bool
 
 	// Attachment
-	Color    string `env:"color,required"`
-	PreText  string `env:"pretext"`
-	Title    string `env:"title"`
-	Message  string `env:"message"`
-	ImageURL string `env:"image_url"`
-	ThumbURL string `env:"thumb_url"`
+	Color    string
+	PreText  string
+	Title    string
+	Message  string
+	ImageURL string
+	ThumbURL string
 }
 
 // ensureNewlines replaces all \n substrings with newline characters.

--- a/main.go
+++ b/main.go
@@ -30,29 +30,29 @@ type Input struct {
 	IconEmojiOnError      string          `env:"emoji_on_error"`
 	IconURL               string          `env:"icon_url"`
 	IconURLOnError        string          `env:"icon_url_on_error"`
+	LinkNames             bool            `env:"link_names,opt[yes,no]"`
 	Username              string          `env:"from_username"`
 	UsernameOnError       string          `env:"from_username_on_error"`
 	ThreadTs              string          `env:"thread_ts"`
 	ThreadTsOnError       string          `env:"thread_ts_on_error"`
 	ReplyBroadcast        bool            `env:"reply_broadcast,opt[yes,no]"`
 	ReplyBroadcastOnError bool            `env:"reply_broadcast_on_error,opt[yes,no]"`
-	LinkNames             bool            `env:"link_names,opt[yes,no]"`
 
 	// Attachment
 	Color           string `env:"color,required"`
 	ColorOnError    string `env:"color_on_error"`
 	PreText         string `env:"pretext"`
 	PreTextOnError  string `env:"pretext_on_error"`
+	AuthorName      string `env:"author_name"`
 	Title           string `env:"title"`
 	TitleOnError    string `env:"title_on_error"`
+	TitleLink       string `env:"title_link"`
 	Message         string `env:"message"`
 	MessageOnError  string `env:"message_on_error"`
 	ImageURL        string `env:"image_url"`
 	ImageURLOnError string `env:"image_url_on_error"`
 	ThumbURL        string `env:"thumb_url"`
 	ThumbURLOnError string `env:"thumb_url_on_error"`
-	AuthorName      string `env:"author_name"`
-	TitleLink       string `env:"title_link"`
 	Footer          string `env:"footer"`
 	FooterIcon      string `env:"footer_icon"`
 	TimeStamp       bool   `env:"timestamp,opt[yes,no]"`

--- a/main.go
+++ b/main.go
@@ -185,24 +185,24 @@ func postMessage(conf Config, msg Message) error {
 	return nil
 }
 
-func validate(conf *Input) error {
-	if conf.APIToken == "" && conf.WebhookURL == "" {
+func validate(inp *Input) error {
+	if inp.APIToken == "" && inp.WebhookURL == "" {
 		return fmt.Errorf("Both API Token and WebhookURL are empty. You need to provide one of them. If you want to use incoming webhooks provide the webhook url. If you want to use a bot to send a message provide the bot API token")
 	}
 
-	if conf.APIToken != "" && conf.WebhookURL != "" {
+	if inp.APIToken != "" && inp.WebhookURL != "" {
 		log.Warnf("Both API Token and WebhookURL are provided. Using the API Token")
-		conf.WebhookURL = ""
+		inp.WebhookURL = ""
 
 	}
 	return nil
 }
 
-func parseInputIntoConfig(cfg *Input) Config {
-	pipelineSuccess := cfg.PipelineBuildStatus == "" ||
-		cfg.PipelineBuildStatus == "succeeded" ||
-		cfg.PipelineBuildStatus == "succeeded_with_abort"
-	success := pipelineSuccess && cfg.BuildStatus == "0"
+func parseInputIntoConfig(inp *Input) Config {
+	pipelineSuccess := inp.PipelineBuildStatus == "" ||
+		inp.PipelineBuildStatus == "succeeded" ||
+		inp.PipelineBuildStatus == "succeeded_with_abort"
+	success := pipelineSuccess && inp.BuildStatus == "0"
 
 	// selectValue chooses the right value based on the result of the build.
 	var selectValue = func(ifSuccess, ifFailed string) string {
@@ -213,21 +213,21 @@ func parseInputIntoConfig(cfg *Input) Config {
 	}
 
 	var config = Config{
-		InputConfig:    cfg.InputConfig,
-		WebhookURL:     selectValue(string(cfg.WebhookURL), string(cfg.WebhookURLOnError)),
-		Channel:        selectValue(cfg.Channel, cfg.ChannelOnError),
-		Text:           selectValue(cfg.Text, cfg.TextOnError),
-		IconEmoji:      selectValue(cfg.IconEmoji, cfg.IconEmojiOnError),
-		IconURL:        selectValue(cfg.IconURL, cfg.IconURLOnError),
-		Username:       selectValue(cfg.Username, cfg.UsernameOnError),
-		ThreadTs:       selectValue(cfg.ThreadTs, cfg.ThreadTsOnError),
-		ReplyBroadcast: (success && cfg.ReplyBroadcast) || (!success && cfg.ReplyBroadcastOnError),
-		Color:          selectValue(cfg.Color, cfg.ColorOnError),
-		PreText:        selectValue(cfg.PreText, cfg.PreTextOnError),
-		Title:          selectValue(cfg.Title, cfg.TitleOnError),
-		Message:        selectValue(cfg.Message, cfg.MessageOnError),
-		ImageURL:       selectValue(cfg.ImageURL, cfg.ImageURLOnError),
-		ThumbURL:       selectValue(cfg.ThumbURL, cfg.ThumbURLOnError),
+		InputConfig:    inp.InputConfig,
+		WebhookURL:     selectValue(string(inp.WebhookURL), string(inp.WebhookURLOnError)),
+		Channel:        selectValue(inp.Channel, inp.ChannelOnError),
+		Text:           selectValue(inp.Text, inp.TextOnError),
+		IconEmoji:      selectValue(inp.IconEmoji, inp.IconEmojiOnError),
+		IconURL:        selectValue(inp.IconURL, inp.IconURLOnError),
+		Username:       selectValue(inp.Username, inp.UsernameOnError),
+		ThreadTs:       selectValue(inp.ThreadTs, inp.ThreadTsOnError),
+		ReplyBroadcast: (success && inp.ReplyBroadcast) || (!success && inp.ReplyBroadcastOnError),
+		Color:          selectValue(inp.Color, inp.ColorOnError),
+		PreText:        selectValue(inp.PreText, inp.PreTextOnError),
+		Title:          selectValue(inp.Title, inp.TitleOnError),
+		Message:        selectValue(inp.Message, inp.MessageOnError),
+		ImageURL:       selectValue(inp.ImageURL, inp.ImageURLOnError),
+		ThumbURL:       selectValue(inp.ThumbURL, inp.ThumbURLOnError),
 	}
 	return config
 

--- a/main.go
+++ b/main.go
@@ -14,9 +14,29 @@ import (
 	"github.com/bitrise-tools/go-steputils/stepconf"
 )
 
-// Config ...
-type Config struct {
+type InputConfig struct {
 	Debug bool `env:"is_debug_mode,opt[yes,no]"`
+
+	// Message
+	APIToken  stepconf.Secret `env:"api_token"`
+	LinkNames bool            `env:"link_names,opt[yes,no]"`
+
+	// Attachment
+	AuthorName string `env:"author_name"`
+	TitleLink  string `env:"title_link"`
+	Footer     string `env:"footer"`
+	FooterIcon string `env:"footer_icon"`
+	TimeStamp  bool   `env:"timestamp,opt[yes,no]"`
+	Fields     string `env:"fields"`
+	Buttons    string `env:"buttons"`
+
+	// Step Outputs
+	ThreadTsOutputVariableName string `env:"output_thread_ts"`
+}
+
+// Input ...
+type Input struct {
+	InputConfig
 
 	// Message
 	WebhookURL            stepconf.Secret `env:"webhook_url"`
@@ -30,7 +50,6 @@ type Config struct {
 	IconEmojiOnError      string          `env:"emoji_on_error"`
 	IconURL               string          `env:"icon_url"`
 	IconURLOnError        string          `env:"icon_url_on_error"`
-	LinkNames             bool            `env:"link_names,opt[yes,no]"`
 	Username              string          `env:"from_username"`
 	UsernameOnError       string          `env:"from_username_on_error"`
 	ThreadTs              string          `env:"thread_ts"`
@@ -43,24 +62,16 @@ type Config struct {
 	ColorOnError    string `env:"color_on_error"`
 	PreText         string `env:"pretext"`
 	PreTextOnError  string `env:"pretext_on_error"`
-	AuthorName      string `env:"author_name"`
 	Title           string `env:"title"`
 	TitleOnError    string `env:"title_on_error"`
-	TitleLink       string `env:"title_link"`
 	Message         string `env:"message"`
 	MessageOnError  string `env:"message_on_error"`
 	ImageURL        string `env:"image_url"`
 	ImageURLOnError string `env:"image_url_on_error"`
 	ThumbURL        string `env:"thumb_url"`
 	ThumbURLOnError string `env:"thumb_url_on_error"`
-	Footer          string `env:"footer"`
-	FooterIcon      string `env:"footer_icon"`
-	TimeStamp       bool   `env:"timestamp,opt[yes,no]"`
-	Fields          string `env:"fields"`
-	Buttons         string `env:"buttons"`
 
 	// Status
-	State               string `env:"set_specific_status,opt[auto,pending,success,error,failure]"`
 	BuildStatus         string `env:"build_status"`
 	PipelineBuildStatus string `env:"pipeline_build_status"`
 
@@ -68,23 +79,26 @@ type Config struct {
 	ThreadTsOutputVariableName string `env:"output_thread_ts"`
 }
 
-// success is true if the build is successful, false otherwise.
-var success = os.Getenv("BITRISE_BUILD_STATUS") == "0"
+type Config struct {
+	InputConfig
 
-// selectValue chooses the right value based on the result of the build.
-func selectValue(ifSuccess, ifFailed string) string {
-	if success || ifFailed == "" {
-		return ifSuccess
-	}
-	return ifFailed
-}
+	// Message
+	WebhookURL     string
+	Channel        string
+	Text           string
+	IconEmoji      string
+	IconURL        string
+	Username       string
+	ThreadTs       string
+	ReplyBroadcast bool
 
-// selectBool chooses the right boolean value based on the result of the build.
-func selectBool(ifSuccess, ifFailed bool) bool {
-	if success {
-		return ifSuccess
-	}
-	return ifFailed
+	// Attachment
+	Color    string `env:"color,required"`
+	PreText  string `env:"pretext"`
+	Title    string `env:"title"`
+	Message  string `env:"message"`
+	ImageURL string `env:"image_url"`
+	ThumbURL string `env:"thumb_url"`
 }
 
 // ensureNewlines replaces all \n substrings with newline characters.
@@ -94,29 +108,29 @@ func ensureNewlines(s string) string {
 
 func newMessage(c Config) Message {
 	msg := Message{
-		Channel: strings.TrimSpace(selectValue(c.Channel, c.ChannelOnError)),
-		Text:    selectValue(c.Text, c.TextOnError),
+		Channel: strings.TrimSpace(c.Channel),
+		Text:    c.Text,
 		Attachments: []Attachment{{
-			Fallback:   ensureNewlines(selectValue(c.Message, c.MessageOnError)),
-			Color:      selectValue(c.Color, c.ColorOnError),
-			PreText:    selectValue(c.PreText, c.PreTextOnError),
+			Fallback:   ensureNewlines(c.Message),
+			Color:      c.Color,
+			PreText:    c.PreText,
 			AuthorName: c.AuthorName,
-			Title:      selectValue(c.Title, c.TitleOnError),
+			Title:      c.Title,
 			TitleLink:  c.TitleLink,
-			Text:       ensureNewlines(selectValue(c.Message, c.MessageOnError)),
+			Text:       ensureNewlines(c.Message),
 			Fields:     parseFields(c.Fields),
-			ImageURL:   selectValue(c.ImageURL, c.ImageURLOnError),
-			ThumbURL:   selectValue(c.ThumbURL, c.ThumbURLOnError),
+			ImageURL:   c.ImageURL,
+			ThumbURL:   c.ThumbURL,
 			Footer:     c.Footer,
 			FooterIcon: c.FooterIcon,
 			Buttons:    parseButtons(c.Buttons),
 		}},
-		IconEmoji:      selectValue(c.IconEmoji, c.IconEmojiOnError),
-		IconURL:        selectValue(c.IconURL, c.IconURLOnError),
+		IconEmoji:      c.IconEmoji,
+		IconURL:        c.IconURL,
 		LinkNames:      c.LinkNames,
-		Username:       selectValue(c.Username, c.UsernameOnError),
-		ThreadTs:       selectValue(c.ThreadTs, c.ThreadTsOnError),
-		ReplyBroadcast: selectBool(c.ReplyBroadcast, c.ReplyBroadcastOnError),
+		Username:       c.Username,
+		ThreadTs:       c.ThreadTs,
+		ReplyBroadcast: c.ReplyBroadcast,
 	}
 	if c.TimeStamp {
 		msg.Attachments[0].TimeStamp = int(time.Now().Unix())
@@ -132,7 +146,7 @@ func postMessage(conf Config, msg Message) error {
 	}
 	log.Debugf("Request to Slack: %s\n", b)
 
-	url := strings.TrimSpace(selectValue(string(conf.WebhookURL), string(conf.WebhookURLOnError)))
+	url := strings.TrimSpace(conf.WebhookURL)
 	if url == "" {
 		url = "https://slack.com/api/chat.postMessage"
 	}
@@ -171,7 +185,7 @@ func postMessage(conf Config, msg Message) error {
 	return nil
 }
 
-func validate(conf *Config) error {
+func validate(conf *Input) error {
 	if conf.APIToken == "" && conf.WebhookURL == "" {
 		return fmt.Errorf("Both API Token and WebhookURL are empty. You need to provide one of them. If you want to use incoming webhooks provide the webhook url. If you want to use a bot to send a message provide the bot API token")
 	}
@@ -184,16 +198,51 @@ func validate(conf *Config) error {
 	return nil
 }
 
-func setSuccess(cfg *Config) {
+func parseConfig(cfg *Input) Config {
 	pipelineSuccess := cfg.PipelineBuildStatus == "" ||
 		cfg.PipelineBuildStatus == "succeeded" ||
 		cfg.PipelineBuildStatus == "succeeded_with_abort"
+	success := pipelineSuccess && cfg.BuildStatus == "0"
 
-	success = pipelineSuccess && cfg.BuildStatus == "0"
+	// selectValue chooses the right value based on the result of the build.
+	var selectValue = func(ifSuccess, ifFailed string) string {
+		if success || ifFailed == "" {
+			return ifSuccess
+		}
+		return ifFailed
+	}
+
+	// selectBool chooses the right boolean value based on the result of the build.
+	var selectBool = func(ifSuccess, ifFailed bool) bool {
+		if success {
+			return ifSuccess
+		}
+		return ifFailed
+	}
+
+	var input = Config{
+		InputConfig:    cfg.InputConfig,
+		WebhookURL:     selectValue(string(cfg.WebhookURL), string(cfg.WebhookURLOnError)),
+		Channel:        selectValue(cfg.Channel, cfg.ChannelOnError),
+		Text:           selectValue(cfg.Text, cfg.TextOnError),
+		IconEmoji:      selectValue(cfg.IconEmoji, cfg.IconEmojiOnError),
+		IconURL:        selectValue(cfg.IconURL, cfg.IconURLOnError),
+		Username:       selectValue(cfg.Username, cfg.UsernameOnError),
+		ThreadTs:       selectValue(cfg.ThreadTs, cfg.ThreadTsOnError),
+		ReplyBroadcast: selectBool(cfg.ReplyBroadcast, cfg.ReplyBroadcastOnError),
+		Color:          selectValue(cfg.Color, cfg.ColorOnError),
+		PreText:        selectValue(cfg.PreText, cfg.PreTextOnError),
+		Title:          selectValue(cfg.Title, cfg.TitleOnError),
+		Message:        selectValue(cfg.Message, cfg.MessageOnError),
+		ImageURL:       selectValue(cfg.ImageURL, cfg.ImageURLOnError),
+		ThumbURL:       selectValue(cfg.ThumbURL, cfg.ThumbURLOnError),
+	}
+	return input
+
 }
 
 func main() {
-	var conf Config
+	var conf Input
 	if err := stepconf.Parse(&conf); err != nil {
 		log.Errorf("Error: %s\n", err)
 		os.Exit(1)
@@ -206,10 +255,10 @@ func main() {
 		os.Exit(1)
 	}
 
-	setSuccess(&conf)
+	input := parseConfig(&conf)
 
-	msg := newMessage(conf)
-	if err := postMessage(conf, msg); err != nil {
+	msg := newMessage(input)
+	if err := postMessage(input, msg); err != nil {
 		log.Errorf("Error: %s", err)
 		os.Exit(1)
 	}

--- a/outputs.go
+++ b/outputs.go
@@ -16,7 +16,7 @@ type SendMessageResponse struct {
 	Timestamp string `json:"ts"`
 }
 
-// / Export the output variables after a successful response
+/// Export the output variables after a successful response
 func exportOutputs(conf *config, resp *http.Response) error {
 
 	if !isRequestingOutput(conf) {
@@ -50,12 +50,12 @@ func exportOutputs(conf *config, resp *http.Response) error {
 
 }
 
-// / Checks if we are requesting an output of anything
+/// Checks if we are requesting an output of anything
 func isRequestingOutput(conf *config) bool {
 	return string(conf.ThreadTsOutputVariableName) != ""
 }
 
-// / Exports env using envman
+/// Exports env using envman
 func exportEnvVariable(variable string, value string) error {
 	c := exec.Command("envman", "add", "--key", variable, "--value", value)
 	err := c.Run()

--- a/outputs.go
+++ b/outputs.go
@@ -16,7 +16,7 @@ type SendMessageResponse struct {
 	Timestamp string `json:"ts"`
 }
 
-/// Export the output variables after a successful response
+// / Export the output variables after a successful response
 func exportOutputs(conf *Config, resp *http.Response) error {
 
 	if !isRequestingOutput(conf) {
@@ -24,7 +24,7 @@ func exportOutputs(conf *Config, resp *http.Response) error {
 		return nil
 	}
 
-	isWebhook := strings.TrimSpace(selectValue(string(conf.WebhookURL), string(conf.WebhookURLOnError))) != ""
+	isWebhook := strings.TrimSpace(conf.WebhookURL) != ""
 
 	// Slack webhooks do not return any useful response information
 	if isWebhook {
@@ -50,12 +50,12 @@ func exportOutputs(conf *Config, resp *http.Response) error {
 
 }
 
-/// Checks if we are requesting an output of anything
+// / Checks if we are requesting an output of anything
 func isRequestingOutput(conf *Config) bool {
 	return string(conf.ThreadTsOutputVariableName) != ""
 }
 
-/// Exports env using envman
+// / Exports env using envman
 func exportEnvVariable(variable string, value string) error {
 	c := exec.Command("envman", "add", "--key", variable, "--value", value)
 	err := c.Run()

--- a/outputs.go
+++ b/outputs.go
@@ -17,7 +17,7 @@ type SendMessageResponse struct {
 }
 
 // / Export the output variables after a successful response
-func exportOutputs(conf *Config, resp *http.Response) error {
+func exportOutputs(conf *config, resp *http.Response) error {
 
 	if !isRequestingOutput(conf) {
 		log.Debugf("Not requesting any outputs")
@@ -51,7 +51,7 @@ func exportOutputs(conf *Config, resp *http.Response) error {
 }
 
 // / Checks if we are requesting an output of anything
-func isRequestingOutput(conf *Config) bool {
+func isRequestingOutput(conf *config) bool {
 	return string(conf.ThreadTsOutputVariableName) != ""
 }
 

--- a/step.yml
+++ b/step.yml
@@ -354,6 +354,36 @@ inputs:
         The *url* is the fully qualified http or https url to deliver users to.
         An attachment may contain 1 to 5 buttons.
 
+# Status Inputs
+
+  - set_specific_status: "auto"
+    opts:
+      title: "Set Specific Build State"
+      summary: "Determines if the build failed or not"
+      description: |-
+        Determines if the build failed or not for choosing between _on_error inputs or the normal ones.
+        
+        If you select `auto`, the step will use `success` status if the current build status is successful (no Step failed previously)
+        or `error` status if the build previously failed. In a pipeline build concurrently executed steps are not taken into account.
+      value_options:
+        - "auto"
+        - "success"
+        - "error"
+  - pipeline_build_status: "$BITRISEIO_PIPELINE_BUILD_STATUS"
+    opts:
+      title: "Pipeline Build Status"
+      summary: "It uses the build state as if the Pipeline Build had finished with the previous stage (if applicable)"
+      description: |-
+        This status will be used to help choosing between _on_error inputs and normal ones when sending the slack message.
+        is_dont_change_value: true
+  - build_status: "$BITRISE_BUILD_STATUS"
+    opts:
+      title: "Build Status"
+      summary: "It sets the build state as if the Build had finished already"
+      description: |-
+        This status will be used to help choosing between _on_error inputs and normal ones.
+      is_dont_change_value: true
+
 # Step Outputs
 
   - output_thread_ts:

--- a/step.yml
+++ b/step.yml
@@ -326,8 +326,8 @@ inputs:
   - fields: |
       App|${BITRISE_APP_TITLE}
       Branch|${BITRISE_GIT_BRANCH}
-      Workflow|${BITRISE_TRIGGERED_WORKFLOW_ID}
       Pipeline|${BITRISEIO_PIPELINE_TITLE}
+      Workflow|${BITRISE_TRIGGERED_WORKFLOW_ID}
     opts:
       title: "A list of fields to be displayed in a table inside the attachment"
       description: |

--- a/step.yml
+++ b/step.yml
@@ -326,7 +326,8 @@ inputs:
   - fields: |
       App|${BITRISE_APP_TITLE}
       Branch|${BITRISE_GIT_BRANCH}
-      Workflow|${BITRISE_TRIGGERED_WORKFLOW_ID}${BITRISEIO_PIPELINE_BUILD_URL:+\nPipeline|$BITRISEIO_PIPELINE_BUILD_URL}
+      Workflow|${BITRISE_TRIGGERED_WORKFLOW_ID}
+      Pipeline|${BITRISEIO_PIPELINE_BUILD_URL}
     opts:
       title: "A list of fields to be displayed in a table inside the attachment"
       description: |
@@ -341,7 +342,8 @@ inputs:
         Empty lines and lines without a separator are omitted.
   - buttons: |
       View App|${BITRISE_APP_URL}
-      View ${BITRISEIO_PIPELINE_BUILD_URL:+Pipeline }Build|${BITRISEIO_PIPELINE_BUILD_URL:-$BITRISE_BUILD_URL}${BITRISEIO_PIPELINE_BUILD_URL:+\nView Workflow Build|$BITRISE_BUILD_URL}
+      View Pipeline Build|${BITRISEIO_PIPELINE_BUILD_URL}
+      View Workflow Build|${BITRISE_BUILD_URL}
       Install Page|${BITRISE_PUBLIC_INSTALL_PAGE_URL}
     opts:
       title: "A list of buttons attached to the message as link buttons"

--- a/step.yml
+++ b/step.yml
@@ -326,7 +326,7 @@ inputs:
   - fields: |
       App|${BITRISE_APP_TITLE}
       Branch|${BITRISE_GIT_BRANCH}
-      Workflow|${BITRISE_TRIGGERED_WORKFLOW_ID}
+      Workflow|${BITRISE_TRIGGERED_WORKFLOW_ID}${BITRISEIO_PIPELINE_BUILD_URL:+\nPipeline|$BITRISEIO_PIPELINE_BUILD_URL}
     opts:
       title: "A list of fields to be displayed in a table inside the attachment"
       description: |
@@ -341,7 +341,7 @@ inputs:
         Empty lines and lines without a separator are omitted.
   - buttons: |
       View App|${BITRISE_APP_URL}
-      View Build|${BITRISE_BUILD_URL}
+      View ${BITRISEIO_PIPELINE_BUILD_URL:+Pipeline }Build|${BITRISEIO_PIPELINE_BUILD_URL:-$BITRISE_BUILD_URL}${BITRISEIO_PIPELINE_BUILD_URL:+\nView Workflow Build|$BITRISE_BUILD_URL}
       Install Page|${BITRISE_PUBLIC_INSTALL_PAGE_URL}
     opts:
       title: "A list of buttons attached to the message as link buttons"
@@ -356,31 +356,18 @@ inputs:
 
 # Status Inputs
 
-  - set_specific_status: "auto"
-    opts:
-      title: "Set Specific Build State"
-      summary: "Determines if the build failed or not"
-      description: |-
-        Determines if the build failed or not for choosing between _on_error inputs or the normal ones.
-        
-        If you select `auto`, the step will use `success` status if the current build status is successful (no Step failed previously)
-        or `error` status if the build previously failed. In a pipeline build concurrently executed steps are not taken into account.
-      value_options:
-        - "auto"
-        - "success"
-        - "error"
   - pipeline_build_status: "$BITRISEIO_PIPELINE_BUILD_STATUS"
     opts:
       title: "Pipeline Build Status"
       summary: "It uses the build state as if the Pipeline Build had finished with the previous stage (if applicable)"
-      description: |-
+      description: |
         This status will be used to help choosing between _on_error inputs and normal ones when sending the slack message.
-        is_dont_change_value: true
+      is_dont_change_value: true
   - build_status: "$BITRISE_BUILD_STATUS"
     opts:
       title: "Build Status"
       summary: "It sets the build state as if the Build had finished already"
-      description: |-
+      description: |
         This status will be used to help choosing between _on_error inputs and normal ones.
       is_dont_change_value: true
 

--- a/step.yml
+++ b/step.yml
@@ -327,7 +327,7 @@ inputs:
       App|${BITRISE_APP_TITLE}
       Branch|${BITRISE_GIT_BRANCH}
       Workflow|${BITRISE_TRIGGERED_WORKFLOW_ID}
-      Pipeline|${BITRISEIO_PIPELINE_BUILD_URL}
+      Pipeline|${BITRISEIO_PIPELINE_TITLE}
     opts:
       title: "A list of fields to be displayed in a table inside the attachment"
       description: |


### PR DESCRIPTION
Env vars shouldn't be used directly by the step. They should be input variables defaulting to the env var.

<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed) ) _Note: README.md is not describing the step itself._

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MAJOR* [version update](https://semver.org/)

The default functionality for pipeline users changes significantly. I believe this is a bugfix, but with a significant change unfortunately pipeline release didn't cover this step.

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

New inputs are added to determine the state of the build instead of using an env var directly from code.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

<!-- 
  Details are important, and help maintainers processing your PR.
  Please list additional details, for example:
  - Update dependencies
  - Make `foo` optional in `main.go`
  - `foo` now returns an `error` for better error handling
-->

- 2 new inputs:
  - BuildStatus: setting the current workflow's build status directly
  - PipelineBuildStatus: setting the pipeline's build status directly
- New default values for `fields` and `buttons` adding pipeline details
- Refactoring to remove the global `success` variable, by introducing Input and Config and parsing Input into Config.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

Alternative suggestion: remove the duplicate inputs for _on_error and rely on the user to set up two instances of this step with different `run_if` parameters to differentiate between the build states. Please note that this would open the possibility to handle more than 2 states without duplicating all the inputs again. 

### Decisions

<!-- Please list decisions that were made for this change. -->

These changes require less change making them easier to adopt, at the same time consistent with the rest of the notification steps, so this solution was chosen and the the alternative outlined above was rejected at this time.

### Other

Jira ticket (for linking): https://bitrise.atlassian.net/browse/BIVS-2072