### PR TITLE
Added support to TS and Footer on error

### DIFF
--- a/main.go
+++ b/main.go
@@ -35,29 +35,33 @@ type Input struct {
 	UsernameOnError       string          `env:"from_username_on_error"`
 	ThreadTs              string          `env:"thread_ts"`
 	ThreadTsOnError       string          `env:"thread_ts_on_error"`
+	Ts                    string          `env:"ts"`
+	TsOnError             string          `env:"ts_on_error"`
 	ReplyBroadcast        bool            `env:"reply_broadcast,opt[yes,no]"`
 	ReplyBroadcastOnError bool            `env:"reply_broadcast_on_error,opt[yes,no]"`
 
 	// Attachment
-	Color           string `env:"color,required"`
-	ColorOnError    string `env:"color_on_error"`
-	PreText         string `env:"pretext"`
-	PreTextOnError  string `env:"pretext_on_error"`
-	AuthorName      string `env:"author_name"`
-	Title           string `env:"title"`
-	TitleOnError    string `env:"title_on_error"`
-	TitleLink       string `env:"title_link"`
-	Message         string `env:"message"`
-	MessageOnError  string `env:"message_on_error"`
-	ImageURL        string `env:"image_url"`
-	ImageURLOnError string `env:"image_url_on_error"`
-	ThumbURL        string `env:"thumb_url"`
-	ThumbURLOnError string `env:"thumb_url_on_error"`
-	Footer          string `env:"footer"`
-	FooterIcon      string `env:"footer_icon"`
-	TimeStamp       bool   `env:"timestamp,opt[yes,no]"`
-	Fields          string `env:"fields"`
-	Buttons         string `env:"buttons"`
+	Color             string `env:"color,required"`
+	ColorOnError      string `env:"color_on_error"`
+	PreText           string `env:"pretext"`
+	PreTextOnError    string `env:"pretext_on_error"`
+	AuthorName        string `env:"author_name"`
+	Title             string `env:"title"`
+	TitleOnError      string `env:"title_on_error"`
+	TitleLink         string `env:"title_link"`
+	Message           string `env:"message"`
+	MessageOnError    string `env:"message_on_error"`
+	ImageURL          string `env:"image_url"`
+	ImageURLOnError   string `env:"image_url_on_error"`
+	ThumbURL          string `env:"thumb_url"`
+	ThumbURLOnError   string `env:"thumb_url_on_error"`
+	Footer            string `env:"footer"`
+	FooterOnError     string `env:"footer_on_error"`
+	FooterIcon        string `env:"footer_icon"`
+	FooterIconOnError string `env:"footer_icon_on_error"`
+	TimeStamp         bool   `env:"timestamp,opt[yes,no]"`
+	Fields            string `env:"fields"`
+	Buttons           string `env:"buttons"`
 
 	// Status
 	BuildStatus         string `env:"build_status"`
@@ -79,6 +83,7 @@ type config struct {
 	IconURL        string
 	Username       string
 	ThreadTs       string
+	Ts             string
 	ReplyBroadcast bool
 	LinkNames      bool `env:"link_names,opt[yes,no]"`
 
@@ -130,6 +135,7 @@ func newMessage(c config) Message {
 		LinkNames:      c.LinkNames,
 		Username:       c.Username,
 		ThreadTs:       c.ThreadTs,
+		Ts:             c.Ts,
 		ReplyBroadcast: c.ReplyBroadcast,
 	}
 	if c.TimeStamp {
@@ -147,8 +153,14 @@ func postMessage(conf config, msg Message) error {
 	log.Debugf("Request to Slack: %s\n", b)
 
 	url := strings.TrimSpace(conf.WebhookURL)
+	ts := strings.TrimSpace(conf.Ts)
+
 	if url == "" {
-		url = "https://slack.com/api/chat.postMessage"
+		if ts == "" {
+			url = "https://slack.com/api/chat.postMessage"
+		} else {
+			url = "https://slack.com/api/chat.update"
+		}
 	}
 
 	req, err := http.NewRequest("POST", url, bytes.NewReader(b))
@@ -232,12 +244,13 @@ func parseInputIntoConfig(inp *Input) config {
 		ThumbURL:                   selectValue(inp.ThumbURL, inp.ThumbURLOnError),
 		AuthorName:                 inp.AuthorName,
 		TitleLink:                  inp.TitleLink,
-		Footer:                     inp.Footer,
-		FooterIcon:                 inp.FooterIcon,
+		Footer:                     selectValue(inp.Footer, inp.FooterOnError),
+		FooterIcon:                 selectValue(inp.FooterIcon, inp.FooterIconOnError),
 		TimeStamp:                  inp.TimeStamp,
 		Fields:                     inp.Fields,
 		Buttons:                    inp.Buttons,
 		ThreadTsOutputVariableName: inp.ThreadTsOutputVariableName,
+		Ts:                         selectValue(inp.Ts, inp.TsOnError),
 	}
 	return config
 

--- a/message.go
+++ b/message.go
@@ -34,6 +34,9 @@ type Message struct {
 	// Provide another message's ts value to make this message a reply.
 	ThreadTs string `json:"thread_ts,omitempty"`
 
+	// Provide another message's ts value to make message to update
+	Ts string `json:"ts,omitempty"`
+
 	// Used in conjunction with thread_ts and indicates whether reply should be made visible to everyone in the channel or conversation.
 	ReplyBroadcast bool `json:"reply_broadcast,omitempty"`
 }

--- a/step.yml
+++ b/step.yml
@@ -186,6 +186,27 @@ inputs:
       title: Thread Timestamp if the build failed
       description: Sends the message as a reply to the message with the given ts if set (in a thread) if the build failed.
       category: If Build Failed
+
+  - ts:
+    opts:
+      title: Message Timestamp
+      summary: Timestamp of the message to be updated.
+      description: |-
+        Timestamp of the message to be updated.
+        
+        When **Message Timestamp** is provided an existing Slack message will be updated, identified by the provided timestamp.  
+        Example: `"1405894322.002768"`.
+  - ts_on_error:
+    opts:
+      title: Message Timestamp if the build failed
+      summary: Timestamp of the message to be updated if the build failed.
+      description: |-
+        Timestamp of the message to be updated if the build failed.
+        
+        When **Message Timestamp if the build failed** is provided an existing Slack message will be updated, identified by the provided timestamp.  
+        Example: `"1405894322.002768"`.
+      category: If Build Failed
+
   - reply_broadcast: "no"
     opts:
       title: Reply Broadcast
@@ -309,12 +330,27 @@ inputs:
         The footer adds some brief text to help contextualize and identify an attachment.
         
         Limited to 300 characters.
+  - footer_on_error: "Bitrise"
+    opts:
+      title: "Footer adds some brief text as footer if the build failed"
+      description: |
+        The footer adds some brief text to help contextualize and identify an attachment.
+        
+        Limited to 300 characters.
+      category: If Build Failed
   - footer_icon: "https://github.com/bitrise-io.png?size=16"
     opts:
       title: "Renders a small icon beside the footer text"
       description: |
         Renders a small icon beside the footer text
         It will be scaled down to 16px by 16px.
+  - footer_icon_on_error: "https://github.com/bitrise-io.png?size=16"
+    opts:
+      title: "Renders a small icon beside the footer text if the build failed"
+      description: |
+        Renders a small icon beside the footer text
+        It will be scaled down to 16px by 16px.
+      category: If Build Failed
   - timestamp: "yes"
     opts:
       title: "Show the current time as part of the attachment's footer?"


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
- [x] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [x] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
Requires a *MINOR* [version update](https://semver.org/)

### Context

<!--- 
  One sentence summary on why the change is needed.
  Describe the big picture of your changes here to communicate to the
  maintainers why we should accept this pull request.
-->

Adds support to update messages using slack step.
Also adds support to the footer message and icon on error.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes
Added 3 new properties:

`ts`: When ts is provided and when using `api_token` it will update the original message with new content. 
To understand how the slack update method works, please check [here](https://api.slack.com/methods/chat.update).

` footer_on_error`: Works in the same way as the others on error.
`footer_icon_on_error`: Works in the same way as the others on error.

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->
N/A

### Decisions

<!-- Please list decisions that were made for this change. -->
